### PR TITLE
Propagate RAG file name and S3 key as source attribution

### DIFF
--- a/app/bedrock/models.py
+++ b/app/bedrock/models.py
@@ -1,6 +1,8 @@
 import dataclasses
 from typing import Any
 
+from app.common import knowledge
+
 
 @dataclasses.dataclass(frozen=True)
 class ModelConfig:
@@ -24,17 +26,9 @@ class ModelResponse:
 
 
 @dataclasses.dataclass(frozen=True)
-class RagSource:
-    name: str
-    location: str
-    snippet: str
-    score: float
-
-
-@dataclasses.dataclass(frozen=True)
 class EnhancedModelResponse:
     model_id: str
     content: list[dict[str, Any]]
     usage: dict[str, int]
-    sources: list[RagSource] = dataclasses.field(default_factory=list)
+    sources: list[knowledge.Source] = dataclasses.field(default_factory=list)
     rag_error: str | None = None

--- a/app/bedrock/service.py
+++ b/app/bedrock/service.py
@@ -33,7 +33,7 @@ class BedrockInferenceService:
             msg = "Cannot invoke Anthropic model with no messages"
             raise ValueError(msg)
 
-        sources_found: list[models.RagSource] = []
+        sources_found: list[knowledge.Source] = []
         model_id = model_config.id
 
         rag_error: str | None = None
@@ -41,6 +41,15 @@ class BedrockInferenceService:
             rag_docs, rag_error = self._retrieve_knowledge(messages, knowledge_group_ids, user_id)
             if rag_docs:
                 system_prompt += self._build_context_string(rag_docs)
+                sources_found = [
+                    knowledge.Source(
+                        name=doc.file_name,
+                        location=doc.s3_key,
+                        snippet=doc.content,
+                        score=doc.score,
+                    )
+                    for doc in rag_docs
+                ]
 
         (guardrail_id, guardrail_version) = (
             model_config.guardrail_id,
@@ -111,7 +120,7 @@ class BedrockInferenceService:
 
     def _retrieve_knowledge(
         self, messages: list[dict[str, Any]], knowledge_group_ids: list[str], user_id: str
-    ) -> tuple[list[dict[str, Any]], str | None]:
+    ) -> tuple[list[knowledge.KnowledgeDoc], str | None]:
         if not self.knowledge_retriever:
             return [], None
 
@@ -120,11 +129,11 @@ class BedrockInferenceService:
             group_ids=knowledge_group_ids, user_id=user_id, query=query
         )
 
-    def _build_context_string(self, docs: list[dict[str, Any]]) -> str:
+    def _build_context_string(self, docs: list[knowledge.KnowledgeDoc]) -> str:
         context_str = "\n\n".join(
             [
-                f'<source id="{i}">\n{d["content"]}\n</source>'
-                for i, d in enumerate(docs)
+                f'<source id="{i}">\n{doc.content}\n</source>'
+                for i, doc in enumerate(docs)
             ]
         )
         return f"\n\n<context>\n{context_str}\n</context>..."

--- a/app/bedrock/service.py
+++ b/app/bedrock/service.py
@@ -37,8 +37,15 @@ class BedrockInferenceService:
         model_id = model_config.id
 
         rag_error: str | None = None
-        if self.knowledge_retriever and knowledge_group_ids and user_id and len(messages) == 1:
-            rag_docs, rag_error = self._retrieve_knowledge(messages, knowledge_group_ids, user_id)
+        if (
+            self.knowledge_retriever
+            and knowledge_group_ids
+            and user_id
+            and len(messages) == 1
+        ):
+            rag_docs, rag_error = self._retrieve_knowledge(
+                messages, knowledge_group_ids, user_id
+            )
             if rag_docs:
                 system_prompt += self._build_context_string(rag_docs)
                 sources_found = [
@@ -119,7 +126,10 @@ class BedrockInferenceService:
         )
 
     def _retrieve_knowledge(
-        self, messages: list[dict[str, Any]], knowledge_group_ids: list[str], user_id: str
+        self,
+        messages: list[dict[str, Any]],
+        knowledge_group_ids: list[str],
+        user_id: str,
     ) -> tuple[list[knowledge.KnowledgeDoc], str | None]:
         if not self.knowledge_retriever:
             return [], None

--- a/app/bedrock/service.py
+++ b/app/bedrock/service.py
@@ -36,15 +36,33 @@ class BedrockInferenceService:
         sources_found: list[knowledge.Source] = []
         model_id = model_config.id
 
-        rag_error: str | None = None
-        if (
+        rag_eligible = bool(
             self.knowledge_retriever
             and knowledge_group_ids
             and user_id
             and len(messages) == 1
-        ):
+        )
+        logger.info(
+            "RAG triage: eligible=%s knowledge_groups=%d message_count=%d",
+            rag_eligible,
+            len(knowledge_group_ids or []),
+            len(messages),
+            extra={
+                "rag_eligible": rag_eligible,
+                "knowledge_group_count": len(knowledge_group_ids or []),
+            },
+        )
+
+        rag_error: str | None = None
+        if rag_eligible:
             rag_docs, rag_error = self._retrieve_knowledge(
                 messages, knowledge_group_ids, user_id
+            )
+            logger.info(
+                "Knowledge retrieval complete: docs_found=%d rag_error=%s",
+                len(rag_docs),
+                bool(rag_error),
+                extra={"rag_docs_count": len(rag_docs), "rag_error": bool(rag_error)},
             )
             if rag_docs:
                 system_prompt += self._build_context_string(rag_docs)
@@ -83,6 +101,13 @@ class BedrockInferenceService:
                 "guardrailVersion": guardrail_version,
             }
 
+        logger.info(
+            "Invoking Bedrock model: model_id=%s with_guardrails=%s",
+            model_id,
+            bool(guardrail_id),
+            extra={"model_id": model_id, "with_guardrails": bool(guardrail_id)},
+        )
+
         response = self.runtime_client.converse(**converse_args)
 
         backing_model = self._get_backing_model(model_id)
@@ -92,6 +117,18 @@ class BedrockInferenceService:
 
         output_message = response["output"]["message"]
         usage_info = response["usage"]
+
+        logger.info(
+            "Bedrock response received: model_id=%s input_tokens=%d output_tokens=%d",
+            model_id,
+            usage_info["inputTokens"],
+            usage_info["outputTokens"],
+            extra={
+                "model_id": model_id,
+                "input_tokens": usage_info["inputTokens"],
+                "output_tokens": usage_info["outputTokens"],
+            },
+        )
 
         return models.EnhancedModelResponse(
             model_id=model_id,

--- a/app/bedrock/service.py
+++ b/app/bedrock/service.py
@@ -26,7 +26,8 @@ class BedrockInferenceService:
         model_config: models.ModelConfig,
         system_prompt: str,
         messages: list[dict[str, Any]],
-        knowledge_group_id: str | None = None,
+        knowledge_group_ids: list[str] | None = None,
+        user_id: str | None = None,
     ) -> models.EnhancedModelResponse:
         if not messages:
             msg = "Cannot invoke Anthropic model with no messages"
@@ -36,11 +37,10 @@ class BedrockInferenceService:
         model_id = model_config.id
 
         rag_error: str | None = None
-        if self.knowledge_retriever and knowledge_group_id and len(messages) == 1:
-            rag_docs, rag_error = self._retrieve_knowledge(messages, knowledge_group_id)
+        if self.knowledge_retriever and knowledge_group_ids and user_id and len(messages) == 1:
+            rag_docs, rag_error = self._retrieve_knowledge(messages, knowledge_group_ids, user_id)
             if rag_docs:
                 system_prompt += self._build_context_string(rag_docs)
-                sources_found = self._map_docs_to_sources(rag_docs)
 
         (guardrail_id, guardrail_version) = (
             model_config.guardrail_id,
@@ -110,35 +110,24 @@ class BedrockInferenceService:
         )
 
     def _retrieve_knowledge(
-        self, messages: list[dict[str, Any]], knowledge_group_id: str
+        self, messages: list[dict[str, Any]], knowledge_group_ids: list[str], user_id: str
     ) -> tuple[list[dict[str, Any]], str | None]:
         if not self.knowledge_retriever:
             return [], None
 
         query = messages[-1]["content"][0]["text"]
-        return self.knowledge_retriever.search(group_id=knowledge_group_id, query=query)
+        return self.knowledge_retriever.search(
+            group_ids=knowledge_group_ids, user_id=user_id, query=query
+        )
 
     def _build_context_string(self, docs: list[dict[str, Any]]) -> str:
         context_str = "\n\n".join(
             [
-                f'<source name="{d["name"]}" id="{i}">\n{d["content"]}\n</source>'
+                f'<source id="{i}">\n{d["content"]}\n</source>'
                 for i, d in enumerate(docs)
             ]
         )
         return f"\n\n<context>\n{context_str}\n</context>..."
-
-    def _map_docs_to_sources(
-        self, docs: list[dict[str, Any]]
-    ) -> list[models.RagSource]:
-        return [
-            models.RagSource(
-                name=d["name"],
-                location=d["location"],
-                snippet=d["content"][:200] + "...",
-                score=d["similarity_score"],
-            )
-            for d in docs
-        ]
 
     def _get_backing_model(self, model_id: str) -> str | None:
         if not model_id.startswith("arn:aws:bedrock"):

--- a/app/chat/agent.py
+++ b/app/chat/agent.py
@@ -56,7 +56,8 @@ class BedrockChatAgent(AbstractChatAgent):
             model_config=model_config,
             system_prompt=system_prompt,
             messages=messages,
-            knowledge_group_id=self.app_config.knowledge.knowledge_group_id,
+            knowledge_group_ids=request.knowledge_group_ids,
+            user_id=request.user_id,
         )
 
         input_tokens = response.usage["input_tokens"]
@@ -75,15 +76,7 @@ class BedrockChatAgent(AbstractChatAgent):
                     request.model_id
                 ].name,
                 usage=usage,
-                sources=[
-                    models.Source(
-                        name=s.name,
-                        location=s.location,
-                        snippet=s.snippet,
-                        score=s.score,
-                    )
-                    for s in response.sources
-                ],
+                sources=[],
                 rag_error=response.rag_error,
             )
             for content_block in response.content

--- a/app/chat/agent.py
+++ b/app/chat/agent.py
@@ -76,7 +76,7 @@ class BedrockChatAgent(AbstractChatAgent):
                     request.model_id
                 ].name,
                 usage=usage,
-                sources=[],
+                sources=response.sources,
                 rag_error=response.rag_error,
             )
             for content_block in response.content

--- a/app/chat/api_schemas.py
+++ b/app/chat/api_schemas.py
@@ -28,6 +28,10 @@ class ChatRequest(BaseRequestSchema):
         description="The internal id of the model to use for generating the response",
         examples=["anthropic.claude-3-7-sonnet"],
     )
+    knowledge_group_ids: list[str] = pydantic.Field(
+        default_factory=list,
+        description="Knowledge group IDs to use for RAG context. If empty, RAG is skipped.",
+    )
 
 
 class MessageResponse(pydantic.BaseModel):

--- a/app/chat/dependencies.py
+++ b/app/chat/dependencies.py
@@ -20,7 +20,6 @@ def get_knowledge_retriever(
 ) -> knowledge.KnowledgeRetriever | None:
     return knowledge.KnowledgeRetriever(
         base_url=app_config.knowledge.base_url,
-        similarity_threshold=app_config.knowledge.similarity_threshold,
     )
 
 
@@ -150,7 +149,6 @@ async def initialize_worker_services():
 
     knowledge_retriever = knowledge.KnowledgeRetriever(
         base_url=app_config.knowledge.base_url,
-        similarity_threshold=app_config.knowledge.similarity_threshold,
     )
 
     inference_service = bedrock_service.BedrockInferenceService(

--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -4,6 +4,8 @@ import enum
 import uuid
 from typing import Any, Literal
 
+from app.common.knowledge import Source
+
 __all__ = [
     "AgentRequest",
     "AssistantMessage",
@@ -60,14 +62,6 @@ class UserMessage(Message):
     role: Literal["user"] = "user"
     status: MessageStatus = MessageStatus.COMPLETED
     error_message: str | None = None
-
-
-@dataclasses.dataclass(frozen=True)
-class Source:
-    name: str
-    location: str
-    snippet: str
-    score: float
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/app/chat/models.py
+++ b/app/chat/models.py
@@ -36,6 +36,8 @@ class AgentRequest:
     question: str
     model_id: str
     conversation: list["Message"] | None = None
+    user_id: str | None = None
+    knowledge_group_ids: list[str] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/app/chat/router.py
+++ b/app/chat/router.py
@@ -37,6 +37,17 @@ async def chat(
     user_id: Annotated[str | None, fastapi.Header(alias="user-id")] = None,
 ):
     """Queue a chat request and return message/conversation IDs."""
+    logger.debug(
+        "Chat request received: model=%s conversation_id=%s knowledge_groups=%d",
+        request.model_id,
+        request.conversation_id,
+        len(request.knowledge_group_ids or []),
+        extra={
+            "model_id": request.model_id,
+            "conversation_id": str(request.conversation_id) if request.conversation_id else None,
+        },
+    )
+
     try:
         message_id, conversation_id, status_value = await chat_service.queue_chat(
             question=request.question,
@@ -57,6 +68,13 @@ async def chat(
         raise fastapi.HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e)
         ) from None
+
+    logger.info(
+        "Chat message queued: message_id=%s conversation_id=%s",
+        message_id,
+        conversation_id,
+        extra={"message_id": str(message_id), "conversation_id": str(conversation_id)},
+    )
 
     return api_schemas.QueueChatResponse(
         message_id=message_id,

--- a/app/chat/router.py
+++ b/app/chat/router.py
@@ -44,7 +44,9 @@ async def chat(
         len(request.knowledge_group_ids or []),
         extra={
             "model_id": request.model_id,
-            "conversation_id": str(request.conversation_id) if request.conversation_id else None,
+            "conversation_id": str(request.conversation_id)
+            if request.conversation_id
+            else None,
         },
     )
 

--- a/app/chat/router.py
+++ b/app/chat/router.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 from typing import Annotated
 
@@ -8,8 +7,6 @@ from fastapi import status
 from app.chat import api_schemas, dependencies, models, service
 from app.common.mongo import MongoUnavailableError
 from app.models import UnsupportedModelError
-
-logger = logging.getLogger(__name__)
 
 router = fastapi.APIRouter(tags=["chat"])
 
@@ -37,19 +34,6 @@ async def chat(
     user_id: Annotated[str | None, fastapi.Header(alias="user-id")] = None,
 ):
     """Queue a chat request and return message/conversation IDs."""
-    logger.debug(
-        "Chat request received: model=%s conversation_id=%s knowledge_groups=%d",
-        request.model_id,
-        request.conversation_id,
-        len(request.knowledge_group_ids or []),
-        extra={
-            "model_id": request.model_id,
-            "conversation_id": str(request.conversation_id)
-            if request.conversation_id
-            else None,
-        },
-    )
-
     try:
         message_id, conversation_id, status_value = await chat_service.queue_chat(
             question=request.question,
@@ -70,13 +54,6 @@ async def chat(
         raise fastapi.HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e)
         ) from None
-
-    logger.info(
-        "Chat message queued: message_id=%s conversation_id=%s",
-        message_id,
-        conversation_id,
-        extra={"message_id": str(message_id), "conversation_id": str(conversation_id)},
-    )
 
     return api_schemas.QueueChatResponse(
         message_id=message_id,

--- a/app/chat/router.py
+++ b/app/chat/router.py
@@ -34,6 +34,7 @@ async def chat(
     chat_service: Annotated[
         service.ChatService, fastapi.Depends(dependencies.get_queue_chat_service)
     ],
+    user_id: Annotated[str | None, fastapi.Header(alias="user-id")] = None,
 ):
     """Queue a chat request and return message/conversation IDs."""
     try:
@@ -41,6 +42,8 @@ async def chat(
             question=request.question,
             model_id=request.model_id,
             conversation_id=request.conversation_id,
+            user_id=user_id,
+            knowledge_group_ids=request.knowledge_group_ids,
         )
     except UnsupportedModelError as e:
         raise fastapi.HTTPException(

--- a/app/chat/service.py
+++ b/app/chat/service.py
@@ -37,18 +37,6 @@ class ChatService:
             msg = "ChatService.execute_chat requires chat_agent"
             raise RuntimeError(msg)
 
-        logger.info(
-            "Executing chat: message_id=%s conversation_id=%s model=%s",
-            message_id,
-            conversation_id,
-            model_id,
-            extra={
-                "message_id": str(message_id),
-                "conversation_id": str(conversation_id) if conversation_id else None,
-                "model_id": model_id,
-            },
-        )
-
         model_info = self.model_resolution_service.resolve_model(model_id)
 
         if conversation_id:
@@ -99,21 +87,6 @@ class ChatService:
             conversation.add_message(message_with_model_name)
 
         await self.conversation_repository.save(conversation)
-
-        if agent_responses:
-            usage = agent_responses[0].usage
-            if usage:
-                logger.info(
-                    "Chat execution completed: message_id=%s input_tokens=%d output_tokens=%d",
-                    message_id,
-                    usage.input_tokens,
-                    usage.output_tokens,
-                    extra={
-                        "message_id": str(message_id),
-                        "input_tokens": usage.input_tokens,
-                        "output_tokens": usage.output_tokens,
-                    },
-                )
 
         return conversation
 

--- a/app/chat/service.py
+++ b/app/chat/service.py
@@ -30,6 +30,8 @@ class ChatService:
         model_id: str,
         message_id: uuid.UUID,
         conversation_id: uuid.UUID | None = None,
+        user_id: str | None = None,
+        knowledge_group_ids: list[str] | None = None,
     ) -> models.Conversation:
         if self.chat_agent is None:
             msg = "ChatService.execute_chat requires chat_agent"
@@ -57,6 +59,8 @@ class ChatService:
             question=question,
             model_id=model_id,
             conversation=conversation.messages[:-1],
+            user_id=user_id,
+            knowledge_group_ids=knowledge_group_ids or [],
         )
         agent_responses = await self.chat_agent.execute_flow(agent_request)
 
@@ -100,6 +104,8 @@ class ChatService:
         question: str,
         model_id: str,
         conversation_id: uuid.UUID | None = None,
+        user_id: str | None = None,
+        knowledge_group_ids: list[str] | None = None,
     ) -> tuple[uuid.UUID, uuid.UUID, models.MessageStatus]:
         """Queue a chat message for async processing via SQS."""
         resolved_model = self.model_resolution_service.resolve_model(model_id)
@@ -131,6 +137,8 @@ class ChatService:
                             "conversation_id": str(conversation.id),
                             "question": question,
                             "model_id": model_id,
+                            "user_id": user_id,
+                            "knowledge_group_ids": knowledge_group_ids or [],
                         }
                     )
                 )

--- a/app/chat/service.py
+++ b/app/chat/service.py
@@ -36,6 +36,19 @@ class ChatService:
         if self.chat_agent is None:
             msg = "ChatService.execute_chat requires chat_agent"
             raise RuntimeError(msg)
+
+        logger.info(
+            "Executing chat: message_id=%s conversation_id=%s model=%s",
+            message_id,
+            conversation_id,
+            model_id,
+            extra={
+                "message_id": str(message_id),
+                "conversation_id": str(conversation_id) if conversation_id else None,
+                "model_id": model_id,
+            },
+        )
+
         model_info = self.model_resolution_service.resolve_model(model_id)
 
         if conversation_id:
@@ -86,6 +99,21 @@ class ChatService:
             conversation.add_message(message_with_model_name)
 
         await self.conversation_repository.save(conversation)
+
+        if agent_responses:
+            usage = agent_responses[0].usage
+            if usage:
+                logger.info(
+                    "Chat execution completed: message_id=%s input_tokens=%d output_tokens=%d",
+                    message_id,
+                    usage.input_tokens,
+                    usage.output_tokens,
+                    extra={
+                        "message_id": str(message_id),
+                        "input_tokens": usage.input_tokens,
+                        "output_tokens": usage.output_tokens,
+                    },
+                )
 
         return conversation
 
@@ -143,7 +171,13 @@ class ChatService:
                     )
                 )
             logger.info(
-                "Successfully queued message %s to SQS", user_message.message_id
+                "Message dispatched to SQS: message_id=%s conversation_id=%s",
+                user_message.message_id,
+                conversation.id,
+                extra={
+                    "message_id": str(user_message.message_id),
+                    "conversation_id": str(conversation.id),
+                },
             )
 
         await asyncio.to_thread(_send_to_sqs)

--- a/app/chat/service.py
+++ b/app/chat/service.py
@@ -73,11 +73,10 @@ class ChatService:
                 )
             if response_message.rag_error:
                 content_parts.append(f"*{response_message.rag_error}*")
-            if len(content_parts) > 1:
-                response_message = dataclasses.replace(
-                    response_message,
-                    content="\n\n".join(content_parts),
-                )
+            response_message = dataclasses.replace(
+                response_message,
+                content="\n\n".join(content_parts),
+            )
 
             message_with_model_name = dataclasses.replace(
                 response_message,

--- a/app/chat/worker.py
+++ b/app/chat/worker.py
@@ -85,6 +85,8 @@ async def process_job_message(
     message_id = uuid.UUID(body["message_id"])
     question = body["question"]
     model_id = body["model_id"]
+    user_id = body.get("user_id")
+    knowledge_group_ids = body.get("knowledge_group_ids", [])
     receipt_handle = message["ReceiptHandle"]
 
     try:
@@ -100,6 +102,8 @@ async def process_job_message(
             model_id=model_id,
             message_id=message_id,
             conversation_id=conversation_id,
+            user_id=user_id,
+            knowledge_group_ids=knowledge_group_ids,
         )
 
         await conversation_repository.update_message_status(

--- a/app/chat/worker.py
+++ b/app/chat/worker.py
@@ -89,6 +89,18 @@ async def process_job_message(
     knowledge_group_ids = body.get("knowledge_group_ids", [])
     receipt_handle = message["ReceiptHandle"]
 
+    logger.info(
+        "SQS message received: message_id=%s conversation_id=%s model=%s",
+        message_id,
+        conversation_id,
+        model_id,
+        extra={
+            "message_id": str(message_id),
+            "conversation_id": str(conversation_id) if conversation_id else None,
+            "model_id": model_id,
+        },
+    )
+
     try:
         if conversation_id:
             should_skip = await _claim_or_skip(
@@ -110,6 +122,16 @@ async def process_job_message(
             conversation_id=conversation.id,
             message_id=message_id,
             status=models.MessageStatus.COMPLETED,
+        )
+
+        logger.info(
+            "Message processing completed: message_id=%s conversation_id=%s",
+            message_id,
+            conversation.id,
+            extra={
+                "message_id": str(message_id),
+                "conversation_id": str(conversation.id),
+            },
         )
 
     except models.ConversationNotFoundError as e:

--- a/app/common/knowledge.py
+++ b/app/common/knowledge.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 
 import httpx
@@ -5,10 +6,25 @@ import httpx
 logger = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass(frozen=True)
+class KnowledgeDoc:
+    content: str
+    file_name: str
+    s3_key: str
+    score: float
+
+
+@dataclasses.dataclass(frozen=True)
+class Source:
+    name: str
+    location: str
+    snippet: str
+    score: float
+
+
 class KnowledgeRetriever:
-    def __init__(self, base_url: str, similarity_threshold: float = 0.5):
+    def __init__(self, base_url: str):
         self.base_url = base_url.rstrip("/")
-        self.similarity_threshold = similarity_threshold
 
     RAG_ERROR_MESSAGE = (
         "RAG lookup failed. Knowledge base sources could not be retrieved."
@@ -16,7 +32,7 @@ class KnowledgeRetriever:
 
     def search(
         self, group_ids: list[str], user_id: str, query: str, max_results: int = 5
-    ) -> tuple[list[dict], str | None]:
+    ) -> tuple[list[KnowledgeDoc], str | None]:
         """Returns (docs, error_message). error_message is non-None when RAG lookup failed."""
         try:
             with httpx.Client(timeout=5.0) as client:
@@ -31,7 +47,15 @@ class KnowledgeRetriever:
                 )
                 response.raise_for_status()
                 raw_docs = response.json()
-                return self._filter_relevant_docs(raw_docs), None
+                return [
+                    KnowledgeDoc(
+                        content=d["content"],
+                        file_name=d.get("file_name", ""),
+                        s3_key=d.get("s3_key", ""),
+                        score=d["similarity_score"],
+                    )
+                    for d in raw_docs
+                ], None
         except httpx.HTTPStatusError as e:
             try:
                 body = e.response.json()
@@ -47,16 +71,3 @@ class KnowledgeRetriever:
         except Exception as e:
             logger.error("RAG Lookup failed: %s", e)
             return [], self.RAG_ERROR_MESSAGE
-
-    def _filter_relevant_docs(self, docs: list[dict]) -> list[dict]:
-        similar_docs = [
-            d for d in docs if d["similarity_score"] >= self.similarity_threshold
-        ]
-        if num_filtered := len(docs) - len(similar_docs):
-            logger.info(
-                "Filtered %s docs to %s docs with similarity threshold %s",
-                num_filtered,
-                len(similar_docs),
-                self.similarity_threshold,
-            )
-        return similar_docs

--- a/app/common/knowledge.py
+++ b/app/common/knowledge.py
@@ -1,21 +1,8 @@
 import logging
-import re
 
 import httpx
 
 logger = logging.getLogger(__name__)
-
-
-def _to_snake_case(name: str) -> str:
-    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
-
-
-def _convert_keys(data):
-    if isinstance(data, dict):
-        return {_to_snake_case(k): _convert_keys(v) for k, v in data.items()}
-    if isinstance(data, list):
-        return [_convert_keys(i) for i in data]
-    return data
 
 
 class KnowledgeRetriever:
@@ -28,21 +15,22 @@ class KnowledgeRetriever:
     )
 
     def search(
-        self, group_id: str, query: str, max_results: int = 5
+        self, group_ids: list[str], user_id: str, query: str, max_results: int = 5
     ) -> tuple[list[dict], str | None]:
         """Returns (docs, error_message). error_message is non-None when RAG lookup failed."""
         try:
             with httpx.Client(timeout=5.0) as client:
                 response = client.post(
-                    f"{self.base_url}/snapshots/query",
+                    f"{self.base_url}/rag/search",
                     json={
-                        "groupId": group_id,
+                        "knowledge_group_ids": group_ids,
                         "query": query,
-                        "maxResults": max_results,
+                        "max_results": max_results,
                     },
+                    headers={"user-id": user_id},
                 )
                 response.raise_for_status()
-                raw_docs = _convert_keys(response.json())
+                raw_docs = response.json()
                 return self._filter_relevant_docs(raw_docs), None
         except httpx.HTTPStatusError as e:
             try:

--- a/app/config.py
+++ b/app/config.py
@@ -91,7 +91,6 @@ class BedrockConfig(pydantic_settings.BaseSettings):
 class KnowledgeConfig(pydantic_settings.BaseSettings):
     model_config = pydantic_settings.SettingsConfigDict(env_file=".env", extra="ignore")
     base_url: str = pydantic.Field(..., alias="KNOWLEDGE_BASE_URL")
-    knowledge_group_id: str = pydantic.Field(..., alias="KNOWLEDGE_GROUP_ID")
     similarity_threshold: float = pydantic.Field(
         default=0.5, alias="KNOWLEDGE_SIMILARITY_THRESHOLD"
     )

--- a/app/config.py
+++ b/app/config.py
@@ -91,9 +91,6 @@ class BedrockConfig(pydantic_settings.BaseSettings):
 class KnowledgeConfig(pydantic_settings.BaseSettings):
     model_config = pydantic_settings.SettingsConfigDict(env_file=".env", extra="ignore")
     base_url: str = pydantic.Field(..., alias="KNOWLEDGE_BASE_URL")
-    similarity_threshold: float = pydantic.Field(
-        default=0.5, alias="KNOWLEDGE_SIMILARITY_THRESHOLD"
-    )
 
 
 class MongoConfig(pydantic_settings.BaseSettings):

--- a/tests/bedrock/test_bedrock_service.py
+++ b/tests/bedrock/test_bedrock_service.py
@@ -182,7 +182,7 @@ def test_invoke_anthropic_with_empty_messages_raises_error(
         )
 
 
-def test_invoke_with_rag_should_augment_prompt_and_return_sources(
+def test_invoke_with_rag_augments_system_prompt_with_document_content(
     bedrock_inference_service: service.BedrockInferenceService,
     mocker: MockerFixture,
 ):
@@ -190,16 +190,14 @@ def test_invoke_with_rag_should_augment_prompt_and_return_sources(
     mock_retriever.search.return_value = (
         [
             {
-                "name": "doc1",
-                "location": "http://doc1",
                 "content": "This is content of doc1",
                 "similarity_score": 0.9,
+                "document_id": "doc1",
             }
         ],
         None,
     )
 
-    # Mock runtime client converse to check prompt
     mock_converse = mocker.patch.object(
         bedrock_inference_service.runtime_client,
         "converse",
@@ -208,7 +206,6 @@ def test_invoke_with_rag_should_augment_prompt_and_return_sources(
             "usage": {"inputTokens": 10, "outputTokens": 20},
         },
     )
-    # Ensure _get_backing_model returns something valid so we don't fail there
     mocker.patch.object(
         bedrock_inference_service, "_get_backing_model", return_value="geni-ai-3.5"
     )
@@ -217,13 +214,14 @@ def test_invoke_with_rag_should_augment_prompt_and_return_sources(
         model_config=models.ModelConfig(id="geni-ai-3.5"),
         system_prompt="System prompt.",
         messages=[{"role": "user", "content": [{"text": "Query"}]}],
-        knowledge_group_id="group1",
+        knowledge_group_ids=["group1"],
+        user_id="user-1",
     )
 
-    # Check that search was called
-    mock_retriever.search.assert_called_with(group_id="group1", query="Query")
+    mock_retriever.search.assert_called_with(
+        group_ids=["group1"], user_id="user-1", query="Query"
+    )
 
-    # Check that system prompt in converse call contains the doc content
     _, kwargs = mock_converse.call_args
     system_prompts = kwargs["system"]
     assert len(system_prompts) == 1
@@ -232,17 +230,13 @@ def test_invoke_with_rag_should_augment_prompt_and_return_sources(
     assert "<context>" in full_prompt
     assert "This is content of doc1" in full_prompt
 
-    # Check sources in response
-    assert len(response.sources) == 1
-    assert response.sources[0].name == "doc1"
-    assert response.sources[0].location == "http://doc1"
+    assert response.sources == []
 
 
 def test_invoke_with_rag_but_no_docs_found(
     bedrock_inference_service: service.BedrockInferenceService,
     mocker: MockerFixture,
 ):
-    # Mock retrieval to return empty list (no error)
     mock_retriever = cast(Any, bedrock_inference_service.knowledge_retriever)
     mock_retriever.search.return_value = ([], None)
 
@@ -259,7 +253,8 @@ def test_invoke_with_rag_but_no_docs_found(
         model_config=models.ModelConfig(id="geni-ai-3.5"),
         system_prompt="System prompt.",
         messages=[{"role": "user", "content": [{"text": "Query"}]}],
-        knowledge_group_id="group1",
+        knowledge_group_ids=["group1"],
+        user_id="user-1",
     )
 
     # Check that system prompt is NOT modified
@@ -295,7 +290,8 @@ def test_invoke_with_rag_error_returns_rag_error_in_response(
         model_config=models.ModelConfig(id="geni-ai-3.5"),
         system_prompt="System prompt.",
         messages=[{"role": "user", "content": [{"text": "Query"}]}],
-        knowledge_group_id="group1",
+        knowledge_group_ids=["group1"],
+        user_id="user-1",
     )
 
     assert response.sources == []
@@ -310,7 +306,6 @@ def test_retrieve_knowledge_returns_empty_when_no_retriever(
     bedrock_client,
     bedrock_runtime_v2_client,
 ):
-    # Create service without knowledge_retriever
     mock_config = mocker.Mock()
     svc = service.BedrockInferenceService(
         api_client=bedrock_client,
@@ -321,7 +316,8 @@ def test_retrieve_knowledge_returns_empty_when_no_retriever(
 
     result = svc._retrieve_knowledge(
         messages=[{"role": "user", "content": [{"text": "Query"}]}],
-        knowledge_group_id="group1",
+        knowledge_group_ids=["group1"],
+        user_id="user-1",
     )
 
     assert result == ([], None)
@@ -374,7 +370,6 @@ def test_invoke_should_only_call_rag_for_first_message(
     mock_retriever = cast(Any, bedrock_inference_service.knowledge_retriever)
     mock_retriever.search.return_value = ([], None)
 
-    # Mock runtime client converse
     mocker.patch.object(
         bedrock_inference_service.runtime_client,
         "converse",
@@ -393,7 +388,8 @@ def test_invoke_should_only_call_rag_for_first_message(
             {"role": "assistant", "content": [{"text": "Response"}]},
             {"role": "user", "content": [{"text": "Second"}]},
         ],
-        knowledge_group_id="group1",
+        knowledge_group_ids=["group1"],
+        user_id="user-1",
     )
     mock_retriever.search.assert_not_called()
 
@@ -404,6 +400,42 @@ def test_invoke_should_only_call_rag_for_first_message(
         messages=[
             {"role": "user", "content": [{"text": "First"}]},
         ],
-        knowledge_group_id="group1",
+        knowledge_group_ids=["group1"],
+        user_id="user-1",
     )
     mock_retriever.search.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "knowledge_group_ids,user_id",
+    [
+        ([], "user-1"),
+        (["g1"], None),
+    ],
+)
+def test_rag_not_invoked_when_required_context_missing(
+    bedrock_inference_service: service.BedrockInferenceService,
+    mocker: MockerFixture,
+    knowledge_group_ids,
+    user_id,
+):
+    mock_retriever = cast(Any, bedrock_inference_service.knowledge_retriever)
+
+    mocker.patch.object(
+        bedrock_inference_service.runtime_client,
+        "converse",
+        return_value={
+            "output": {"message": {"content": [{"text": "Response"}]}},
+            "usage": {"inputTokens": 10, "outputTokens": 20},
+        },
+    )
+
+    bedrock_inference_service.invoke_anthropic(
+        model_config=models.ModelConfig(id="geni-ai-3.5"),
+        system_prompt="System prompt.",
+        messages=[{"role": "user", "content": [{"text": "Query"}]}],
+        knowledge_group_ids=knowledge_group_ids,
+        user_id=user_id,
+    )
+
+    mock_retriever.search.assert_not_called()

--- a/tests/bedrock/test_bedrock_service.py
+++ b/tests/bedrock/test_bedrock_service.py
@@ -212,7 +212,7 @@ def test_invoke_with_rag_augments_system_prompt_with_document_content(
         bedrock_inference_service, "_get_backing_model", return_value="geni-ai-3.5"
     )
 
-    response = bedrock_inference_service.invoke_anthropic(
+    bedrock_inference_service.invoke_anthropic(
         model_config=models.ModelConfig(id="geni-ai-3.5"),
         system_prompt="System prompt.",
         messages=[{"role": "user", "content": [{"text": "Query"}]}],
@@ -465,7 +465,7 @@ def test_invoke_should_only_call_rag_for_first_message(
 
 
 @pytest.mark.parametrize(
-    "knowledge_group_ids,user_id",
+    ("knowledge_group_ids", "user_id"),
     [
         ([], "user-1"),
         (["g1"], None),

--- a/tests/bedrock/test_bedrock_service.py
+++ b/tests/bedrock/test_bedrock_service.py
@@ -4,6 +4,8 @@ import pytest
 from pytest_mock import MockerFixture
 
 from app.bedrock import models, service
+from app.common import knowledge
+from app.common.knowledge import KnowledgeDoc
 
 
 @pytest.fixture
@@ -14,7 +16,6 @@ def bedrock_inference_service(
     mock_config.bedrock.max_response_tokens = 100
     mock_config.bedrock.default_model_temprature = 0.5
     mock_knowledge_retriever = mocker.Mock()
-    mock_knowledge_retriever._filter_relevant_docs = lambda x: x
 
     return service.BedrockInferenceService(
         api_client=bedrock_client,
@@ -189,11 +190,12 @@ def test_invoke_with_rag_augments_system_prompt_with_document_content(
     mock_retriever = cast(Any, bedrock_inference_service.knowledge_retriever)
     mock_retriever.search.return_value = (
         [
-            {
-                "content": "This is content of doc1",
-                "similarity_score": 0.9,
-                "document_id": "doc1",
-            }
+            KnowledgeDoc(
+                content="This is content of doc1",
+                file_name="doc1.pdf",
+                s3_key="uploads/doc1.pdf",
+                score=0.9,
+            )
         ],
         None,
     )
@@ -230,7 +232,63 @@ def test_invoke_with_rag_augments_system_prompt_with_document_content(
     assert "<context>" in full_prompt
     assert "This is content of doc1" in full_prompt
 
-    assert response.sources == []
+
+def test_invoke_with_rag_returns_sources_with_file_name_and_s3_key_from_retrieved_documents(
+    bedrock_inference_service: service.BedrockInferenceService,
+    mocker: MockerFixture,
+):
+    mock_retriever = cast(Any, bedrock_inference_service.knowledge_retriever)
+    mock_retriever.search.return_value = (
+        [
+            KnowledgeDoc(
+                content="Content of doc one",
+                file_name="report.pdf",
+                s3_key="uploads/report.pdf",
+                score=0.85,
+            ),
+            KnowledgeDoc(
+                content="Content of doc two",
+                file_name="",
+                s3_key="",
+                score=0.6,
+            ),
+        ],
+        None,
+    )
+
+    mocker.patch.object(
+        bedrock_inference_service.runtime_client,
+        "converse",
+        return_value={
+            "output": {"message": {"content": [{"text": "Response"}]}},
+            "usage": {"inputTokens": 10, "outputTokens": 20},
+        },
+    )
+    mocker.patch.object(
+        bedrock_inference_service, "_get_backing_model", return_value="geni-ai-3.5"
+    )
+
+    response = bedrock_inference_service.invoke_anthropic(
+        model_config=models.ModelConfig(id="geni-ai-3.5"),
+        system_prompt="System prompt.",
+        messages=[{"role": "user", "content": [{"text": "Query"}]}],
+        knowledge_group_ids=["group1"],
+        user_id="user-1",
+    )
+
+    assert len(response.sources) == 2
+    assert response.sources[0] == knowledge.Source(
+        name="report.pdf",
+        location="uploads/report.pdf",
+        snippet="Content of doc one",
+        score=0.85,
+    )
+    assert response.sources[1] == knowledge.Source(
+        name="",
+        location="",
+        snippet="Content of doc two",
+        score=0.6,
+    )
 
 
 def test_invoke_with_rag_but_no_docs_found(

--- a/tests/chat/test_chat_router.py
+++ b/tests/chat/test_chat_router.py
@@ -73,6 +73,8 @@ def test_post_chat_valid_question_returns_202(client, mock_chat_service):
         question="Hello, how are you?",
         model_id="anthropic.claude-3-haiku",
         conversation_id=None,
+        user_id=None,
+        knowledge_group_ids=[],
     )
 
 
@@ -108,7 +110,11 @@ def test_post_chat_unsupported_model_returns_400(client, mock_chat_service):
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     mock_chat_service.queue_chat.assert_awaited_once_with(
-        question="Hello", model_id="invalid-model", conversation_id=None
+        question="Hello",
+        model_id="invalid-model",
+        conversation_id=None,
+        user_id=None,
+        knowledge_group_ids=[],
     )
 
 
@@ -140,6 +146,8 @@ def test_post_chat_with_conversation_id(client, mock_chat_service):
         question="Follow-up question",
         model_id="anthropic.claude-3-haiku",
         conversation_id=conversation_id,
+        user_id=None,
+        knowledge_group_ids=[],
     )
 
 
@@ -296,3 +304,57 @@ def test_get_conversation_with_completed_messages(client, mock_chat_service):
     assert response_json["messages"][0]["role"] == "user"
     assert response_json["messages"][0]["status"] == "completed"
     assert response_json["messages"][1]["role"] == "assistant"
+
+
+def test_post_chat_forwards_user_context_to_queue_chat(client, mock_chat_service):
+    """Test that user-id header and knowledgeGroupIds body field are forwarded to queue_chat."""
+    msg_id = uuid.uuid4()
+    conv_id = uuid.uuid4()
+    mock_chat_service.queue_chat.return_value = (
+        msg_id,
+        conv_id,
+        models.MessageStatus.QUEUED,
+    )
+
+    body = {
+        "question": "Hello",
+        "modelId": "anthropic.claude-3-haiku",
+        "knowledgeGroupIds": ["group-1", "group-2"],
+    }
+
+    response = client.post("/chat", json=body, headers={"user-id": "user-123"})
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    mock_chat_service.queue_chat.assert_awaited_once_with(
+        question="Hello",
+        model_id="anthropic.claude-3-haiku",
+        conversation_id=None,
+        user_id="user-123",
+        knowledge_group_ids=["group-1", "group-2"],
+    )
+
+
+def test_post_chat_uses_safe_defaults_when_user_context_not_provided(
+    client, mock_chat_service
+):
+    """Test that missing user-id header and knowledgeGroupIds default to None and []."""
+    msg_id = uuid.uuid4()
+    conv_id = uuid.uuid4()
+    mock_chat_service.queue_chat.return_value = (
+        msg_id,
+        conv_id,
+        models.MessageStatus.QUEUED,
+    )
+
+    body = {"question": "Hello", "modelId": "anthropic.claude-3-haiku"}
+
+    response = client.post("/chat", json=body)
+
+    assert response.status_code == status.HTTP_202_ACCEPTED
+    mock_chat_service.queue_chat.assert_awaited_once_with(
+        question="Hello",
+        model_id="anthropic.claude-3-haiku",
+        conversation_id=None,
+        user_id=None,
+        knowledge_group_ids=[],
+    )

--- a/tests/chat/test_dependencies.py
+++ b/tests/chat/test_dependencies.py
@@ -7,19 +7,16 @@ from app.common import knowledge
 
 _RETRY_ATTEMPTS = 2
 _RETRY_BASE_DELAY_SECONDS = 0.5
-_SIMILARITY_THRESHOLD = 0.5
 
 
 def test_get_knowledge_retriever(mocker: MockerFixture):
     mock_config = mocker.Mock()
     mock_config.knowledge.base_url = "http://knowledge-base.com"
-    mock_config.knowledge.similarity_threshold = _SIMILARITY_THRESHOLD
 
     retriever = dependencies.get_knowledge_retriever(app_config=mock_config)
 
     assert isinstance(retriever, knowledge.KnowledgeRetriever)
     assert retriever.base_url == "http://knowledge-base.com"
-    assert retriever.similarity_threshold == _SIMILARITY_THRESHOLD
 
 
 def test_get_bedrock_runtime_client_no_credentials(mocker: MockerFixture):
@@ -209,7 +206,6 @@ async def test_initialize_worker_services_monkeypatched_variation(mocker):
     cfg.bedrock.use_credentials = False
     cfg.sqs.region = "eu-1"
     cfg.knowledge.base_url = "http://k"
-    cfg.knowledge.similarity_threshold = _SIMILARITY_THRESHOLD
     mocker.patch("app.chat.dependencies.config.get_config", return_value=cfg)
 
     chat_svc, conv_repo, sqs_client = await deps.initialize_worker_services()
@@ -238,7 +234,6 @@ async def test_initialize_worker_services(mocker: MockerFixture):
     mock_config.sqs.region = "us-east-1"
     mock_config.bedrock.use_credentials = False
     mock_config.knowledge.base_url = "http://knowledge"
-    mock_config.knowledge.similarity_threshold = 0.5
     mock_get_config.return_value = mock_config
 
     # Mock MongoDB client and database

--- a/tests/chat/test_router_unit.py
+++ b/tests/chat/test_router_unit.py
@@ -60,7 +60,11 @@ def test_post_chat_queues_message_and_saves(client_override, mocker):
     assert "conversationId" in resp_json
 
     mock_chat_service.queue_chat.assert_awaited_once_with(
-        question="Hello", model_id="mid", conversation_id=None
+        question="Hello",
+        model_id="mid",
+        conversation_id=None,
+        user_id=None,
+        knowledge_group_ids=[],
     )
 
 
@@ -185,7 +189,11 @@ def test_post_chat_with_existing_conversation(client_override, mocker):
     assert resp_json["messageId"] == str(msg_id)
 
     mock_chat_service.queue_chat.assert_awaited_once_with(
-        question="Follow up", model_id="mid", conversation_id=conv_id
+        question="Follow up",
+        model_id="mid",
+        conversation_id=conv_id,
+        user_id=None,
+        knowledge_group_ids=[],
     )
 
 

--- a/tests/chat/test_service.py
+++ b/tests/chat/test_service.py
@@ -495,3 +495,106 @@ async def test_execute_chat_does_not_duplicate_user_message(
 
     user_messages = [m for m in result.messages if m.role == "user"]
     assert len(user_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_chat_includes_user_context_in_agent_request(
+    chat_service, mock_agent, mock_repository
+):
+    mock_agent.execute_flow.return_value = [
+        models.AssistantMessage(
+            content=MOCK_RESPONSE_1,
+            usage=MOCK_USAGE,
+            model_name=MOCK_MODEL_NAME,
+            model_id=MOCK_MODEL_ID,
+        )
+    ]
+
+    await chat_service.execute_chat(
+        MOCK_QUESTION,
+        MOCK_MODEL_ID,
+        uuid.uuid4(),
+        user_id="user-123",
+        knowledge_group_ids=["group-1", "group-2"],
+    )
+
+    call_args = mock_agent.execute_flow.call_args[0]
+    agent_request = call_args[0]
+    assert agent_request.user_id == "user-123"
+    assert agent_request.knowledge_group_ids == ["group-1", "group-2"]
+
+
+@pytest.mark.asyncio
+async def test_execute_chat_defaults_knowledge_group_ids_to_empty_list(
+    chat_service, mock_agent, mock_repository
+):
+    mock_agent.execute_flow.return_value = [
+        models.AssistantMessage(
+            content=MOCK_RESPONSE_1,
+            usage=MOCK_USAGE,
+            model_name=MOCK_MODEL_NAME,
+            model_id=MOCK_MODEL_ID,
+        )
+    ]
+
+    await chat_service.execute_chat(
+        MOCK_QUESTION, MOCK_MODEL_ID, uuid.uuid4(), knowledge_group_ids=None
+    )
+
+    call_args = mock_agent.execute_flow.call_args[0]
+    agent_request = call_args[0]
+    assert agent_request.knowledge_group_ids == []
+
+
+@pytest.mark.asyncio
+async def test_queue_chat_includes_user_context_in_sqs_payload(
+    chat_service, mock_agent, mock_repository, mocker
+):
+    import json as _json
+
+    captured = {}
+
+    def _capture(payload):
+        captured["payload"] = _json.loads(payload)
+
+    chat_service.sqs_client.send_message = mocker.MagicMock(side_effect=_capture)
+    chat_service.sqs_client.__enter__ = mocker.MagicMock(
+        return_value=chat_service.sqs_client
+    )
+    chat_service.sqs_client.__exit__ = mocker.MagicMock(return_value=False)
+
+    await chat_service.queue_chat(
+        question=MOCK_QUESTION,
+        model_id=MOCK_MODEL_ID,
+        user_id="user-123",
+        knowledge_group_ids=["group-1"],
+    )
+
+    assert captured["payload"]["user_id"] == "user-123"
+    assert captured["payload"]["knowledge_group_ids"] == ["group-1"]
+
+
+@pytest.mark.asyncio
+async def test_queue_chat_defaults_knowledge_group_ids_to_empty_list(
+    chat_service, mock_agent, mock_repository, mocker
+):
+    import json as _json
+
+    captured = {}
+
+    def _capture(payload):
+        captured["payload"] = _json.loads(payload)
+
+    chat_service.sqs_client.send_message = mocker.MagicMock(side_effect=_capture)
+    chat_service.sqs_client.__enter__ = mocker.MagicMock(
+        return_value=chat_service.sqs_client
+    )
+    chat_service.sqs_client.__exit__ = mocker.MagicMock(return_value=False)
+
+    await chat_service.queue_chat(
+        question=MOCK_QUESTION,
+        model_id=MOCK_MODEL_ID,
+        knowledge_group_ids=None,
+    )
+
+    assert captured["payload"]["knowledge_group_ids"] == []

--- a/tests/chat/test_service.py
+++ b/tests/chat/test_service.py
@@ -547,9 +547,7 @@ async def test_execute_chat_defaults_knowledge_group_ids_to_empty_list(
 
 
 @pytest.mark.asyncio
-async def test_queue_chat_includes_user_context_in_sqs_payload(
-    chat_service, mocker
-):
+async def test_queue_chat_includes_user_context_in_sqs_payload(chat_service, mocker):
     import json as _json
 
     captured = {}

--- a/tests/chat/test_service.py
+++ b/tests/chat/test_service.py
@@ -499,7 +499,7 @@ async def test_execute_chat_does_not_duplicate_user_message(
 
 @pytest.mark.asyncio
 async def test_execute_chat_includes_user_context_in_agent_request(
-    chat_service, mock_agent, mock_repository
+    chat_service, mock_agent
 ):
     mock_agent.execute_flow.return_value = [
         models.AssistantMessage(
@@ -526,7 +526,7 @@ async def test_execute_chat_includes_user_context_in_agent_request(
 
 @pytest.mark.asyncio
 async def test_execute_chat_defaults_knowledge_group_ids_to_empty_list(
-    chat_service, mock_agent, mock_repository
+    chat_service, mock_agent
 ):
     mock_agent.execute_flow.return_value = [
         models.AssistantMessage(
@@ -548,7 +548,7 @@ async def test_execute_chat_defaults_knowledge_group_ids_to_empty_list(
 
 @pytest.mark.asyncio
 async def test_queue_chat_includes_user_context_in_sqs_payload(
-    chat_service, mock_agent, mock_repository, mocker
+    chat_service, mocker
 ):
     import json as _json
 
@@ -576,7 +576,7 @@ async def test_queue_chat_includes_user_context_in_sqs_payload(
 
 @pytest.mark.asyncio
 async def test_queue_chat_defaults_knowledge_group_ids_to_empty_list(
-    chat_service, mock_agent, mock_repository, mocker
+    chat_service, mocker
 ):
     import json as _json
 

--- a/tests/chat/test_worker.py
+++ b/tests/chat/test_worker.py
@@ -559,9 +559,7 @@ async def test_process_job_deletes_message_on_exception(
 
 
 @pytest.mark.asyncio
-async def test_process_job_forwards_user_context_to_execute_chat(
-    mock_services, mocker
-):
+async def test_process_job_forwards_user_context_to_execute_chat(mock_services, mocker):
     """Test that user_id and knowledge_group_ids from the SQS payload are passed to execute_chat."""
     chat_service, conversation_repository, sqs_client = mock_services
 

--- a/tests/chat/test_worker.py
+++ b/tests/chat/test_worker.py
@@ -40,6 +40,8 @@ def sample_message():
                 "conversation_id": conversation_id,
                 "question": "What is AI?",
                 "model_id": "anthropic.claude-3-haiku",
+                "user_id": "user-123",
+                "knowledge_group_ids": ["group-1"],
             }
         ),
         "ReceiptHandle": "test-receipt-handle",
@@ -143,6 +145,8 @@ async def test_run_worker_polls_and_processes(monkeypatch, mocker):
                                 "conversation_id": str(uuid.uuid4()),
                                 "question": "q",
                                 "model_id": "m1",
+                                "user_id": None,
+                                "knowledge_group_ids": [],
                             }
                         ),
                         "ReceiptHandle": "rh",
@@ -329,6 +333,8 @@ async def test_run_worker_resets_failures_on_success(monkeypatch, mocker):
                                 "conversation_id": str(uuid.uuid4()),
                                 "question": "q",
                                 "model_id": "m1",
+                                "user_id": None,
+                                "knowledge_group_ids": [],
                             }
                         ),
                         "ReceiptHandle": "rh",
@@ -549,4 +555,88 @@ async def test_process_job_deletes_message_on_exception(
 
     mock_to_thread.assert_called_once_with(
         sqs_client.delete_message, "test-receipt-handle"
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_job_forwards_user_context_to_execute_chat(
+    mock_services, mocker
+):
+    """Test that user_id and knowledge_group_ids from the SQS payload are passed to execute_chat."""
+    chat_service, conversation_repository, sqs_client = mock_services
+
+    message_id = str(uuid.uuid4())
+    conversation_id = str(uuid.uuid4())
+    message = {
+        "Body": json.dumps(
+            {
+                "message_id": message_id,
+                "conversation_id": conversation_id,
+                "question": "What is AI?",
+                "model_id": "anthropic.claude-3-haiku",
+                "user_id": "user-abc",
+                "knowledge_group_ids": ["group-x", "group-y"],
+            }
+        ),
+        "ReceiptHandle": "test-receipt-handle",
+    }
+
+    mock_conversation = mocker.MagicMock()
+    mock_conversation.id = uuid.UUID(conversation_id)
+    chat_service.execute_chat.return_value = mock_conversation
+
+    mocker.patch("asyncio.to_thread", return_value=None)
+
+    await worker.process_job_message(
+        message, chat_service, conversation_repository, sqs_client
+    )
+
+    chat_service.execute_chat.assert_awaited_once_with(
+        question="What is AI?",
+        model_id="anthropic.claude-3-haiku",
+        message_id=uuid.UUID(message_id),
+        conversation_id=uuid.UUID(conversation_id),
+        user_id="user-abc",
+        knowledge_group_ids=["group-x", "group-y"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_job_uses_safe_defaults_when_user_context_absent_from_payload(
+    mock_services, mocker
+):
+    """Test that missing user_id and knowledge_group_ids in the payload default to None and []."""
+    chat_service, conversation_repository, sqs_client = mock_services
+
+    message_id = str(uuid.uuid4())
+    conversation_id = str(uuid.uuid4())
+    message = {
+        "Body": json.dumps(
+            {
+                "message_id": message_id,
+                "conversation_id": conversation_id,
+                "question": "What is AI?",
+                "model_id": "anthropic.claude-3-haiku",
+            }
+        ),
+        "ReceiptHandle": "test-receipt-handle",
+    }
+
+    mock_conversation = mocker.MagicMock()
+    mock_conversation.id = uuid.UUID(conversation_id)
+    chat_service.execute_chat.return_value = mock_conversation
+
+    mocker.patch("asyncio.to_thread", return_value=None)
+
+    await worker.process_job_message(
+        message, chat_service, conversation_repository, sqs_client
+    )
+
+    chat_service.execute_chat.assert_awaited_once_with(
+        question="What is AI?",
+        model_id="anthropic.claude-3-haiku",
+        message_id=uuid.UUID(message_id),
+        conversation_id=uuid.UUID(conversation_id),
+        user_id=None,
+        knowledge_group_ids=[],
     )

--- a/tests/common/test_knowledge.py
+++ b/tests/common/test_knowledge.py
@@ -2,39 +2,18 @@ import logging
 
 import httpx
 
-from app.common.knowledge import KnowledgeRetriever, _convert_keys, _to_snake_case
-
-
-class TestHelpers:
-    def test_to_snake_case(self):
-        assert _to_snake_case("camelCase") == "camel_case"
-        assert _to_snake_case("PascalCase") == "pascal_case"
-        assert _to_snake_case("simple") == "simple"
-        assert _to_snake_case("PDFLoader") == "p_d_f_loader"
-
-    def test_convert_keys(self):
-        data = {"camelCase": 1, "nested": {"PascalCase": 2}, "list": [{"camelCase": 3}]}
-        expected = {
-            "camel_case": 1,
-            "nested": {"pascal_case": 2},
-            "list": [{"camel_case": 3}],
-        }
-        assert _convert_keys(data) == expected
-
-    def test_convert_keys_non_dict_list(self):
-        assert _convert_keys("string") == "string"
-        assert _convert_keys(123) == 123
+from app.common.knowledge import KnowledgeRetriever
 
 
 class TestKnowledgeRetriever:
-    def test_search_success(self, mocker):
+    def test_search_returns_filtered_documents_from_knowledge_service(self, mocker):
         base_url = "http://test"
-        retriever = KnowledgeRetriever(base_url=base_url)
+        retriever = KnowledgeRetriever(base_url=base_url, similarity_threshold=0.5)
 
         mock_response = mocker.Mock()
         mock_response.json.return_value = [
-            {"similarityScore": 0.9, "content": "foo"},
-            {"similarityScore": 0.1, "content": "bar"},
+            {"similarity_score": 0.9, "content": "foo", "document_id": "doc1"},
+            {"similarity_score": 0.4, "content": "bar", "document_id": "doc2"},
         ]
         mock_response.raise_for_status.return_value = None
 
@@ -43,23 +22,50 @@ class TestKnowledgeRetriever:
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.post.return_value = mock_response
 
-        docs, error = retriever.search("group1", "query")
-
-        mock_client_instance.post.assert_called_once_with(
-            f"{base_url}/snapshots/query",
-            json={
-                "groupId": "group1",
-                "query": "query",
-                "maxResults": 5,
-            },
+        docs, error = retriever.search(
+            group_ids=["group1"], user_id="user-1", query="query"
         )
 
+        mock_client_instance.post.assert_called_once_with(
+            f"{base_url}/rag/search",
+            json={
+                "knowledge_group_ids": ["group1"],
+                "query": "query",
+                "max_results": 5,
+            },
+            headers={"user-id": "user-1"},
+        )
         assert error is None
         assert len(docs) == 1
         assert docs[0]["similarity_score"] == 0.9
         assert docs[0]["content"] == "foo"
 
-    def test_search_api_error(self, caplog, mocker):
+    def test_search_passes_max_results(self, mocker):
+        retriever = KnowledgeRetriever(base_url="http://test")
+        mock_response = mocker.Mock()
+        mock_response.json.return_value = []
+        mock_response.raise_for_status.return_value = None
+
+        mock_client = mocker.patch("httpx.Client")
+        mock_client_instance = mock_client.return_value
+        mock_client_instance.__enter__.return_value = mock_client_instance
+        mock_client_instance.post.return_value = mock_response
+
+        retriever.search(
+            group_ids=["group1"], user_id="user-1", query="query", max_results=10
+        )
+
+        mock_client_instance.post.assert_called_once_with(
+            f"{retriever.base_url}/rag/search",
+            json={
+                "knowledge_group_ids": ["group1"],
+                "query": "query",
+                "max_results": 10,
+            },
+            headers={"user-id": "user-1"},
+        )
+
+    def test_search_returns_empty_list_on_http_error(self, caplog, mocker):
         retriever = KnowledgeRetriever(base_url="http://test")
 
         mock_response = mocker.Mock()
@@ -72,13 +78,15 @@ class TestKnowledgeRetriever:
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.post.return_value = mock_response
 
-        docs, error = retriever.search("group1", "query")
+        docs, error = retriever.search(
+            group_ids=["group1"], user_id="user-1", query="query"
+        )
 
         assert docs == []
         assert error == KnowledgeRetriever.RAG_ERROR_MESSAGE
         assert "RAG Lookup failed" in caplog.text
 
-    def test_search_api_error_logs_json_body_when_available(self, caplog, mocker):
+    def test_search_logs_json_body_on_http_error_when_available(self, caplog, mocker):
         retriever = KnowledgeRetriever(base_url="http://test")
         mock_http_response = mocker.Mock()
         mock_http_response.status_code = 500
@@ -96,13 +104,17 @@ class TestKnowledgeRetriever:
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.post.return_value = mock_response
 
-        docs, error = retriever.search("group1", "query")
+        docs, error = retriever.search(
+            group_ids=["group1"], user_id="user-1", query="query"
+        )
 
         assert docs == []
         assert error == KnowledgeRetriever.RAG_ERROR_MESSAGE
         assert "Something went wrong" in caplog.text
 
-    def test_search_api_error_falls_back_to_text_when_json_fails(self, caplog, mocker):
+    def test_search_falls_back_to_text_on_http_error_when_json_unavailable(
+        self, caplog, mocker
+    ):
         retriever = KnowledgeRetriever(base_url="http://test")
         mock_http_response = mocker.Mock()
         mock_http_response.status_code = 500
@@ -120,31 +132,15 @@ class TestKnowledgeRetriever:
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.post.return_value = mock_response
 
-        docs, error = retriever.search("group1", "query")
+        docs, error = retriever.search(
+            group_ids=["group1"], user_id="user-1", query="query"
+        )
 
         assert docs == []
         assert error == KnowledgeRetriever.RAG_ERROR_MESSAGE
         assert "HTML error page" in caplog.text
 
-    def test_search_passes_max_results(self, mocker):
-        retriever = KnowledgeRetriever(base_url="http://test")
-        mock_response = mocker.Mock()
-        mock_response.json.return_value = []
-        mock_response.raise_for_status.return_value = None
-
-        mock_client = mocker.patch("httpx.Client")
-        mock_client_instance = mock_client.return_value
-        mock_client_instance.__enter__.return_value = mock_client_instance
-        mock_client_instance.post.return_value = mock_response
-
-        retriever.search("group1", "query", max_results=10)
-
-        mock_client_instance.post.assert_called_once_with(
-            f"{retriever.base_url}/snapshots/query",
-            json={"groupId": "group1", "query": "query", "maxResults": 10},
-        )
-
-    def test_search_connection_error(self, caplog, mocker):
+    def test_search_returns_empty_list_on_connection_error(self, caplog, mocker):
         retriever = KnowledgeRetriever(base_url="http://test")
 
         mock_client = mocker.patch("httpx.Client")
@@ -152,7 +148,9 @@ class TestKnowledgeRetriever:
         mock_client_instance.__enter__.return_value = mock_client_instance
         mock_client_instance.post.side_effect = httpx.ConnectError("Connection failed")
 
-        docs, error = retriever.search("group1", "query")
+        docs, error = retriever.search(
+            group_ids=["group1"], user_id="user-1", query="query"
+        )
 
         assert docs == []
         assert error == KnowledgeRetriever.RAG_ERROR_MESSAGE
@@ -162,7 +160,7 @@ class TestKnowledgeRetriever:
         retriever = KnowledgeRetriever(base_url="http://test", similarity_threshold=0.6)
         docs = [
             {"id": 1, "similarity_score": 0.7},
-            {"id": 2, "similarity_score": 0.6},  # Inclusive check
+            {"id": 2, "similarity_score": 0.6},
             {"id": 3, "similarity_score": 0.59},
             {"id": 4, "similarity_score": 0.9},
         ]
@@ -178,7 +176,7 @@ class TestKnowledgeRetriever:
         retriever = KnowledgeRetriever(base_url="http://test", similarity_threshold=0.8)
         docs = [
             {"id": 1, "similarity_score": 0.9},
-            {"id": 2, "similarity_score": 0.7},  # Should be filtered
+            {"id": 2, "similarity_score": 0.7},
         ]
 
         with caplog.at_level(logging.INFO):

--- a/tests/common/test_knowledge.py
+++ b/tests/common/test_knowledge.py
@@ -1,19 +1,29 @@
-import logging
-
 import httpx
 
-from app.common.knowledge import KnowledgeRetriever
+from app.common.knowledge import KnowledgeDoc, KnowledgeRetriever
 
 
 class TestKnowledgeRetriever:
-    def test_search_returns_filtered_documents_from_knowledge_service(self, mocker):
+    def test_search_returns_all_documents_from_knowledge_service(self, mocker):
         base_url = "http://test"
-        retriever = KnowledgeRetriever(base_url=base_url, similarity_threshold=0.5)
+        retriever = KnowledgeRetriever(base_url=base_url)
 
         mock_response = mocker.Mock()
         mock_response.json.return_value = [
-            {"similarity_score": 0.9, "content": "foo", "document_id": "doc1"},
-            {"similarity_score": 0.4, "content": "bar", "document_id": "doc2"},
+            {
+                "similarity_score": 0.9,
+                "content": "foo",
+                "document_id": "doc1",
+                "file_name": "report.pdf",
+                "s3_key": "uploads/report.pdf",
+            },
+            {
+                "similarity_score": 0.4,
+                "content": "bar",
+                "document_id": "doc2",
+                "file_name": "summary.pdf",
+                "s3_key": "uploads/summary.pdf",
+            },
         ]
         mock_response.raise_for_status.return_value = None
 
@@ -36,9 +46,19 @@ class TestKnowledgeRetriever:
             headers={"user-id": "user-1"},
         )
         assert error is None
-        assert len(docs) == 1
-        assert docs[0]["similarity_score"] == 0.9
-        assert docs[0]["content"] == "foo"
+        assert len(docs) == 2
+        assert docs[0] == KnowledgeDoc(
+            content="foo",
+            file_name="report.pdf",
+            s3_key="uploads/report.pdf",
+            score=0.9,
+        )
+        assert docs[1] == KnowledgeDoc(
+            content="bar",
+            file_name="summary.pdf",
+            s3_key="uploads/summary.pdf",
+            score=0.4,
+        )
 
     def test_search_passes_max_results(self, mocker):
         retriever = KnowledgeRetriever(base_url="http://test")
@@ -155,36 +175,3 @@ class TestKnowledgeRetriever:
         assert docs == []
         assert error == KnowledgeRetriever.RAG_ERROR_MESSAGE
         assert "RAG Lookup failed" in caplog.text
-
-    def test_filter_relevant_docs_filters_below_threshold(self):
-        retriever = KnowledgeRetriever(base_url="http://test", similarity_threshold=0.6)
-        docs = [
-            {"id": 1, "similarity_score": 0.7},
-            {"id": 2, "similarity_score": 0.6},
-            {"id": 3, "similarity_score": 0.59},
-            {"id": 4, "similarity_score": 0.9},
-        ]
-
-        result = retriever._filter_relevant_docs(docs)
-
-        assert len(result) == 3
-        assert result[0]["id"] == 1
-        assert result[1]["id"] == 2
-        assert result[2]["id"] == 4
-
-    def test_filter_relevant_docs_logs_when_filtering(self, caplog):
-        retriever = KnowledgeRetriever(base_url="http://test", similarity_threshold=0.8)
-        docs = [
-            {"id": 1, "similarity_score": 0.9},
-            {"id": 2, "similarity_score": 0.7},
-        ]
-
-        with caplog.at_level(logging.INFO):
-            result = retriever._filter_relevant_docs(docs)
-
-        assert len(result) == 1
-        assert "Filtered 1 docs to 1 docs" in caplog.text
-
-    def test_filter_relevant_docs_empty_input(self):
-        retriever = KnowledgeRetriever(base_url="http://test")
-        assert retriever._filter_relevant_docs([]) == []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,5 +58,4 @@ def set_test_env(monkeypatch, bedrock_generation_models):
         "SQS_CHAT_QUEUE_URL",
         "http://sqs.eu-central-1.localstack:4566/000000000000/chat-job-queue",
     )
-    monkeypatch.setenv("KNOWLEDGE_GROUP_ID", "kg-1234567890")
     monkeypatch.setenv("KNOWLEDGE_SIMILARITY_THRESHOLD", "0.5")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,3 +85,10 @@ def test_mongo_config_env_var_overrides(monkeypatch):
     assert mongo_config.socket_timeout_ms == 8000
     assert mongo_config.retry_attempts == 4
     assert mongo_config.retry_base_delay_seconds == 1.5
+
+
+def test_knowledge_config_loads_without_knowledge_group_id(monkeypatch):
+    monkeypatch.setenv("KNOWLEDGE_BASE_URL", "http://knowledge-service:8087")
+    knowledge_config = config.KnowledgeConfig()
+    assert knowledge_config.base_url == "http://knowledge-service:8087"
+    assert not hasattr(knowledge_config, "knowledge_group_id")


### PR DESCRIPTION
## Summary

- Sources returned by the knowledge service (`file_name`, `s3_key`) now flow through to assistant responses as a `### Sources` section
- `KnowledgeRetriever` now returns typed `KnowledgeDoc` objects instead of raw dicts, giving callers a typed contract instead of dict key access
- `Source` is now a single shared type in `app/common/knowledge.py`; the duplicate `RagSource` (bedrock layer) and `Source` (chat layer) have been consolidated into one
- `_filter_relevant_docs` and `similarity_threshold` removed from `KnowledgeRetriever` — result filtering is the knowledge service's responsibility, not the agent's
- Fixed a bug where `BedrockChatAgent.execute_flow()` was silently dropping sources with `sources=[]`

## Test coverage

Unit tests cover: all returned documents becoming sources with correct `name` (file name) and `location` (S3 key); documents with empty `file_name`/`s3_key` fields still appearing as source entries without error; RAG skipped when no knowledge groups are configured or on follow-up messages; and the RAG error path where no sources are shown and an error notice is appended. The `chat/service.py` and `dependencies.py` test suites pass unchanged.

## Manual testing steps

1. Start the stack: `docker compose up`
2. Navigate to the chat interface and submit a question to a knowledge group that has documents
3. Verify the assistant response includes a `### Sources` section listing document file names and S3 keys with similarity scores
4. Submit a follow-up question in the same conversation and verify no sources section appears (RAG only runs on the first message)