### PR TITLE
AICE-297 - Added timeouts to AWS Bedrock calls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ AWS_EMF_SERVICE_TYPE=python-backend-service
 AWS_BEARER_TOKEN_BEDROCK=
 AWS_BEDROCK_DEFAULT_GENERATION_MODEL=
 AWS_BEDROCK_AVAILABLE_GENERATION_MODELS='[{"modelId": "geni-ai-3.5", "name": "Geni AI 3.5", "description": "A powerful conversational AI model suitable for a wide range of tasks.", "bedrockModelId": "geni-ai-3.5"}, {"modelId": "geni-ai-4", "name": "Geni AI 4", "description": "An advanced conversational AI model with enhanced understanding and generation capabilities.", "bedrockModelId": "geni-ai-4"}]'
+AWS_BEDROCK_CONNECT_TIMEOUT=60
+AWS_BEDROCK_READ_TIMEOUT=60
 
 KNOWLEDGE_BASE_URL="http://localhost:8085"
 KNOWLEDGE_GROUP_ID="kg_34vf0wr3e06l"
@@ -21,3 +23,9 @@ KNOWLEDGE_SIMILARITY_THRESHOLD=0.5
 
 AWS_SQS_ENDPOINT_URL=http://localstack:4566
 SQS_CHAT_QUEUE_URL=http://sqs.eu-west-2.127.0.0.1.localstack.cloud:4566/000000000000/ai-defra-search-agent-invoke
+
+MONGO_SERVER_SELECTION_TIMEOUT_MS=5000
+MONGO_CONNECT_TIMEOUT_MS=5000
+MONGO_SOCKET_TIMEOUT_MS=10000
+MONGO_RETRY_ATTEMPTS=2
+MONGO_RETRY_BASE_DELAY_SECONDS=0.5

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The following environment variables can be configured for the application:
 | `AWS_BEARER_TOKEN_BEDROCK` | No | N/A                      | Bearer token for AWS Bedrock authentication                             |
 | `AWS_BEDROCK_DEFAULT_GENERATION_MODEL` | Yes | N/A                      | Default AI model to use for generation                                  |
 | `AWS_BEDROCK_AVAILABLE_GENERATION_MODELS` | Yes | N/A                      | JSON array of available AI models for generation                        |
+| `AWS_BEDROCK_CONNECT_TIMEOUT` | No | `60`                     | Timeout in seconds to establish a connection to AWS Bedrock             |
+| `AWS_BEDROCK_READ_TIMEOUT` | No | `60`                     | Timeout in seconds to wait for a response from AWS Bedrock              |
 | `KNOWLEDGE_BASE_URL` | No | N/A                      | URL of the knowledge base service used for RAG lookup                   |
 | `KNOWLEDGE_GROUP_ID` | No | N/A                      | Knowledge group identifier for retrieval queries                        |
 | `KNOWLEDGE_SIMILARITY_THRESHOLD` | No | `0.5`                    | Similarity threshold for knowledge retrieval matches (0-1)              |

--- a/app/chat/dependencies.py
+++ b/app/chat/dependencies.py
@@ -1,6 +1,7 @@
 import logging
 
 import boto3
+import botocore.config
 import fastapi
 import pymongo.asynchronous.database
 
@@ -29,7 +30,13 @@ def get_prompt_repository() -> FileSystemPromptRepository:
 
 
 def _bedrock_client_kwargs(app_config: config.AppConfig) -> dict:
-    kwargs: dict = {"region_name": app_config.sqs.region}
+    kwargs: dict = {
+        "region_name": app_config.sqs.region,
+        "config": botocore.config.Config(
+            connect_timeout=app_config.bedrock.connect_timeout,
+            read_timeout=app_config.bedrock.read_timeout,
+        ),
+    }
     if app_config.bedrock.use_credentials:
         kwargs["aws_access_key_id"] = app_config.bedrock.access_key_id
         kwargs["aws_secret_access_key"] = app_config.bedrock.secret_access_key

--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,10 @@ class BedrockConfig(pydantic_settings.BaseSettings):
     endpoint_url: str | None = pydantic.Field(
         default=None, alias="BEDROCK_ENDPOINT_URL"
     )
+    connect_timeout: int = pydantic.Field(
+        default=60, alias="AWS_BEDROCK_CONNECT_TIMEOUT"
+    )
+    read_timeout: int = pydantic.Field(default=60, alias="AWS_BEDROCK_READ_TIMEOUT")
 
     @pydantic.field_validator("available_generation_models", mode="before")
     @classmethod

--- a/tests/chat/test_dependencies.py
+++ b/tests/chat/test_dependencies.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -26,13 +28,20 @@ def test_get_bedrock_runtime_client_no_credentials(mocker: MockerFixture):
     mock_config = mocker.Mock()
     mock_config.bedrock.use_credentials = False
     mock_config.bedrock.endpoint_url = None
+    mock_config.bedrock.connect_timeout = 60
+    mock_config.bedrock.read_timeout = 60
     mock_config.sqs.region = "us-east-1"
 
     mock_boto3 = mocker.patch("boto3.client")
 
     client = dependencies.get_bedrock_runtime_client(app_config=mock_config)
 
-    mock_boto3.assert_called_with("bedrock-runtime", region_name="us-east-1")
+    mock_boto3.assert_called_with(
+        "bedrock-runtime", region_name="us-east-1", config=ANY
+    )
+    _, kwargs = mock_boto3.call_args
+    assert kwargs["config"].connect_timeout == 60
+    assert kwargs["config"].read_timeout == 60
     assert client == mock_boto3.return_value
 
 
@@ -42,6 +51,8 @@ def test_get_bedrock_runtime_client_with_credentials(mocker: MockerFixture):
     mock_config.bedrock.access_key_id = "test-key"
     mock_config.bedrock.secret_access_key = "test-secret"  # noqa: S105
     mock_config.bedrock.endpoint_url = None
+    mock_config.bedrock.connect_timeout = 60
+    mock_config.bedrock.read_timeout = 60
     mock_config.sqs.region = "us-east-1"
 
     mock_boto3 = mocker.patch("boto3.client")
@@ -50,10 +61,14 @@ def test_get_bedrock_runtime_client_with_credentials(mocker: MockerFixture):
 
     mock_boto3.assert_called_with(
         "bedrock-runtime",
+        region_name="us-east-1",
+        config=ANY,
         aws_access_key_id="test-key",
         aws_secret_access_key="test-secret",  # noqa: S106
-        region_name="us-east-1",
     )
+    _, kwargs = mock_boto3.call_args
+    assert kwargs["config"].connect_timeout == 60
+    assert kwargs["config"].read_timeout == 60
     assert client == mock_boto3.return_value
 
 
@@ -61,13 +76,18 @@ def test_get_bedrock_client_no_credentials(mocker: MockerFixture):
     mock_config = mocker.Mock()
     mock_config.bedrock.use_credentials = False
     mock_config.bedrock.endpoint_url = None
+    mock_config.bedrock.connect_timeout = 60
+    mock_config.bedrock.read_timeout = 60
     mock_config.sqs.region = "us-east-1"
 
     mock_boto3 = mocker.patch("boto3.client")
 
     client = dependencies.get_bedrock_client(app_config=mock_config)
 
-    mock_boto3.assert_called_with("bedrock", region_name="us-east-1")
+    mock_boto3.assert_called_with("bedrock", region_name="us-east-1", config=ANY)
+    _, kwargs = mock_boto3.call_args
+    assert kwargs["config"].connect_timeout == 60
+    assert kwargs["config"].read_timeout == 60
     assert client == mock_boto3.return_value
 
 
@@ -77,6 +97,8 @@ def test_get_bedrock_client_with_credentials(mocker: MockerFixture):
     mock_config.bedrock.access_key_id = "test-key"
     mock_config.bedrock.secret_access_key = "test-secret"  # noqa: S105
     mock_config.bedrock.endpoint_url = None
+    mock_config.bedrock.connect_timeout = 60
+    mock_config.bedrock.read_timeout = 60
     mock_config.sqs.region = "us-east-1"
 
     mock_boto3 = mocker.patch("boto3.client")
@@ -85,10 +107,14 @@ def test_get_bedrock_client_with_credentials(mocker: MockerFixture):
 
     mock_boto3.assert_called_with(
         "bedrock",
+        region_name="us-east-1",
+        config=ANY,
         aws_access_key_id="test-key",
         aws_secret_access_key="test-secret",  # noqa: S106
-        region_name="us-east-1",
     )
+    _, kwargs = mock_boto3.call_args
+    assert kwargs["config"].connect_timeout == 60
+    assert kwargs["config"].read_timeout == 60
     assert client == mock_boto3.return_value
 
 
@@ -207,6 +233,9 @@ async def test_initialize_worker_services_monkeypatched_variation(mocker):
     cfg = mocker.Mock()
     cfg.mongo.database = "db"
     cfg.bedrock.use_credentials = False
+    cfg.bedrock.endpoint_url = None
+    cfg.bedrock.connect_timeout = 60
+    cfg.bedrock.read_timeout = 60
     cfg.sqs.region = "eu-1"
     cfg.knowledge.base_url = "http://k"
     cfg.knowledge.similarity_threshold = _SIMILARITY_THRESHOLD
@@ -237,6 +266,9 @@ async def test_initialize_worker_services(mocker: MockerFixture):
     mock_config.mongo.database = "test_db"
     mock_config.sqs.region = "us-east-1"
     mock_config.bedrock.use_credentials = False
+    mock_config.bedrock.endpoint_url = None
+    mock_config.bedrock.connect_timeout = 60
+    mock_config.bedrock.read_timeout = 60
     mock_config.knowledge.base_url = "http://knowledge"
     mock_config.knowledge.similarity_threshold = 0.5
     mock_get_config.return_value = mock_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,3 +85,18 @@ def test_mongo_config_env_var_overrides(monkeypatch):
     assert mongo_config.socket_timeout_ms == 8000
     assert mongo_config.retry_attempts == 4
     assert mongo_config.retry_base_delay_seconds == 1.5
+
+
+def test_bedrock_config_defaults():
+    bedrock_config = config.BedrockConfig()
+    assert bedrock_config.connect_timeout == 60
+    assert bedrock_config.read_timeout == 60
+
+
+def test_bedrock_config_env_var_overrides(monkeypatch):
+    monkeypatch.setenv("AWS_BEDROCK_CONNECT_TIMEOUT", "10")
+    monkeypatch.setenv("AWS_BEDROCK_READ_TIMEOUT", "120")
+
+    bedrock_config = config.BedrockConfig()
+    assert bedrock_config.connect_timeout == 10
+    assert bedrock_config.read_timeout == 120


### PR DESCRIPTION
AICE-297 - Added timeouts to AWS Bedrock calls. These can be configured by environment variables.