### PR TITLE
update trivy

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run Aqua Trivy scan
         id: trivy-scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-ref: .
           scan-type: repository


### PR DESCRIPTION
Pin aquasecurity/trivy-action to commit SHA to prevent mutable tag supply chain risk (0.35.0)