### PR TITLE
Add rag_error field to MessageResponse and update message serialization

### DIFF
--- a/app/chat/api_schemas.py
+++ b/app/chat/api_schemas.py
@@ -62,6 +62,12 @@ class MessageResponse(pydantic.BaseModel):
         exclude_if=lambda v: v is None,
         serialization_alias="errorMessage",
     )
+    rag_error: str | None = pydantic.Field(
+        default=None,
+        description="Set when RAG retrieval failed for an assistant message",
+        exclude_if=lambda v: v is None,
+        serialization_alias="ragError",
+    )
     timestamp: datetime.datetime = pydantic.Field(
         description="The timestamp of when the message was created"
     )

--- a/app/chat/router.py
+++ b/app/chat/router.py
@@ -13,6 +13,34 @@ logger = logging.getLogger(__name__)
 router = fastapi.APIRouter(tags=["chat"])
 
 
+def _message_to_response(msg: models.Message) -> api_schemas.MessageResponse:
+    if isinstance(msg, models.UserMessage):
+        return api_schemas.MessageResponse(
+            message_id=msg.message_id,
+            role=msg.role,
+            content=msg.content,
+            model_id=msg.model_id,
+            model_name=msg.model_name,
+            status=msg.status.value,
+            error_message=msg.error_message,
+            timestamp=msg.timestamp,
+        )
+    if isinstance(msg, models.AssistantMessage):
+        return api_schemas.MessageResponse(
+            message_id=msg.message_id,
+            role=msg.role,
+            content=msg.content,
+            model_id=msg.model_id,
+            model_name=msg.model_name,
+            status=models.MessageStatus.COMPLETED.value,
+            error_message=None,
+            rag_error=msg.rag_error,
+            timestamp=msg.timestamp,
+        )
+    msg_t = type(msg).__name__
+    raise TypeError(f"Unsupported message type: {msg_t}")
+
+
 @router.post(
     "/chat",
     status_code=status.HTTP_202_ACCEPTED,
@@ -93,23 +121,7 @@ async def get_conversation(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e)
         ) from None
 
-    messages = [
-        api_schemas.MessageResponse(
-            message_id=msg.message_id,
-            role=msg.role,
-            content=msg.content,
-            model_id=msg.model_id,
-            model_name=msg.model_name,
-            status=msg.status.value
-            if isinstance(msg, models.UserMessage)
-            else models.MessageStatus.COMPLETED.value,
-            error_message=msg.error_message
-            if isinstance(msg, models.UserMessage)
-            else None,
-            timestamp=msg.timestamp,
-        )
-        for msg in conversation.messages
-    ]
+    messages = [_message_to_response(msg) for msg in conversation.messages]
 
     return api_schemas.ChatResponse(
         conversation_id=conversation.id,

--- a/tests/chat/test_router_unit.py
+++ b/tests/chat/test_router_unit.py
@@ -136,6 +136,38 @@ def test_get_conversation_returns_data(client_override, mocker):
     data = resp.json()
     assert data["conversationId"] == str(conversation.id)
     assert len(data["messages"]) == 2
+    assert data["messages"][1].get("ragError") is None
+
+
+def test_get_conversation_serializes_rag_error_on_assistant(client_override, mocker):
+    test_client = client_override
+
+    conversation = models.Conversation()
+    user_msg = models.UserMessage(content="q", model_id="m", model_name="mn")
+    rag_err = "RAG lookup failed. Knowledge base sources could not be retrieved."
+    assistant_msg = models.AssistantMessage(
+        content="a",
+        model_id="m",
+        model_name="mn",
+        usage=models.TokenUsage(1, 2, 3),
+        rag_error=rag_err,
+    )
+    conversation.add_message(user_msg)
+    conversation.add_message(assistant_msg)
+
+    mock_chat_service = mocker.AsyncMock()
+    mock_chat_service.get_conversation.return_value = conversation
+
+    from app.chat import dependencies
+
+    app.dependency_overrides[dependencies.get_queue_chat_service] = (
+        lambda: mock_chat_service
+    )
+
+    resp = test_client.get(f"/conversations/{conversation.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["messages"][1]["ragError"] == rag_err
 
 
 def test_post_chat_with_unsupported_model_returns_400(client_override, mocker):

--- a/tests/chat/test_router_unit.py
+++ b/tests/chat/test_router_unit.py
@@ -1,3 +1,4 @@
+import dataclasses
 import uuid
 
 import fastapi.testclient
@@ -137,6 +138,19 @@ def test_get_conversation_returns_data(client_override, mocker):
     assert data["conversationId"] == str(conversation.id)
     assert len(data["messages"]) == 2
     assert data["messages"][1].get("ragError") is None
+
+
+def test_message_to_response_raises_for_unknown_message_subclass():
+    """Exhaustiveness branch: not UserMessage, not AssistantMessage -> TypeError."""
+    from app.chat.router import _message_to_response
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class OrphanMessage(models.Message):
+        role: str = "system"
+
+    msg = OrphanMessage(content="c", model_id="mid", model_name="mname")
+    with pytest.raises(TypeError, match="Unsupported message type: OrphanMessage"):
+        _message_to_response(msg)
 
 
 def test_get_conversation_serializes_rag_error_on_assistant(client_override, mocker):


### PR DESCRIPTION
- Introduced `rag_error` field in `MessageResponse` to capture RAG retrieval failures.
- Refactored message serialization logic in the router to utilize a dedicated function for improved clarity and maintainability.
- Added unit tests to validate the serialization of `rag_error` in assistant messages.