### PR TITLE
AICE-469 - pass the X-API-KEY header when calling the knowledge servi…

### DIFF
--- a/app/chat/dependencies.py
+++ b/app/chat/dependencies.py
@@ -21,6 +21,7 @@ def get_knowledge_retriever(
 ) -> knowledge.KnowledgeRetriever | None:
     return knowledge.KnowledgeRetriever(
         base_url=app_config.knowledge.base_url,
+        api_key=app_config.knowledge.api_key.get_secret_value(),
     )
 
 
@@ -156,6 +157,7 @@ async def initialize_worker_services():
 
     knowledge_retriever = knowledge.KnowledgeRetriever(
         base_url=app_config.knowledge.base_url,
+        api_key=app_config.knowledge.api_key.get_secret_value(),
     )
 
     inference_service = bedrock_service.BedrockInferenceService(

--- a/app/common/knowledge.py
+++ b/app/common/knowledge.py
@@ -23,8 +23,9 @@ class Source:
 
 
 class KnowledgeRetriever:
-    def __init__(self, base_url: str):
+    def __init__(self, base_url: str, api_key: str):
         self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
 
     RAG_ERROR_MESSAGE = (
         "RAG lookup failed. Knowledge base sources could not be retrieved."
@@ -43,7 +44,7 @@ class KnowledgeRetriever:
                         "query": query,
                         "max_results": max_results,
                     },
-                    headers={"user-id": user_id},
+                    headers={"user-id": user_id, "X-API-KEY": self.api_key},
                 )
                 response.raise_for_status()
                 raw_docs = response.json()

--- a/app/config.py
+++ b/app/config.py
@@ -95,6 +95,9 @@ class BedrockConfig(pydantic_settings.BaseSettings):
 class KnowledgeConfig(pydantic_settings.BaseSettings):
     model_config = pydantic_settings.SettingsConfigDict(env_file=".env", extra="ignore")
     base_url: str = pydantic.Field(..., alias="KNOWLEDGE_BASE_URL")
+    api_key: pydantic.SecretStr = pydantic.Field(
+        ..., alias="AI_DEFRA_SEARCH_KNOWLEDGE_API_KEY"
+    )
 
 
 class MongoConfig(pydantic_settings.BaseSettings):

--- a/tests/chat/test_dependencies.py
+++ b/tests/chat/test_dependencies.py
@@ -14,11 +14,13 @@ _RETRY_BASE_DELAY_SECONDS = 0.5
 def test_get_knowledge_retriever(mocker: MockerFixture):
     mock_config = mocker.Mock()
     mock_config.knowledge.base_url = "http://knowledge-base.com"
+    mock_config.knowledge.api_key.get_secret_value.return_value = "test-api-key"
 
     retriever = dependencies.get_knowledge_retriever(app_config=mock_config)
 
     assert isinstance(retriever, knowledge.KnowledgeRetriever)
     assert retriever.base_url == "http://knowledge-base.com"
+    assert retriever.api_key == "test-api-key"
 
 
 def test_get_bedrock_runtime_client_no_credentials(mocker: MockerFixture):
@@ -235,6 +237,7 @@ async def test_initialize_worker_services_monkeypatched_variation(mocker):
     cfg.bedrock.read_timeout = 60
     cfg.sqs.region = "eu-1"
     cfg.knowledge.base_url = "http://k"
+    cfg.knowledge.api_key.get_secret_value.return_value = "test-api-key"
     mocker.patch("app.chat.dependencies.config.get_config", return_value=cfg)
 
     chat_svc, conv_repo, sqs_client = await deps.initialize_worker_services()
@@ -266,6 +269,7 @@ async def test_initialize_worker_services(mocker: MockerFixture):
     mock_config.bedrock.connect_timeout = 60
     mock_config.bedrock.read_timeout = 60
     mock_config.knowledge.base_url = "http://knowledge"
+    mock_config.knowledge.api_key.get_secret_value.return_value = "test-api-key"
     mock_get_config.return_value = mock_config
 
     # Mock MongoDB client and database

--- a/tests/common/test_knowledge.py
+++ b/tests/common/test_knowledge.py
@@ -6,7 +6,7 @@ from app.common.knowledge import KnowledgeDoc, KnowledgeRetriever
 class TestKnowledgeRetriever:
     def test_search_returns_all_documents_from_knowledge_service(self, mocker):
         base_url = "http://test"
-        retriever = KnowledgeRetriever(base_url=base_url)
+        retriever = KnowledgeRetriever(base_url=base_url, api_key="test-api-key")
 
         mock_response = mocker.Mock()
         mock_response.json.return_value = [
@@ -43,7 +43,7 @@ class TestKnowledgeRetriever:
                 "query": "query",
                 "max_results": 5,
             },
-            headers={"user-id": "user-1"},
+            headers={"user-id": "user-1", "X-API-KEY": "test-api-key"},
         )
         assert error is None
         assert len(docs) == 2
@@ -61,7 +61,7 @@ class TestKnowledgeRetriever:
         )
 
     def test_search_passes_max_results(self, mocker):
-        retriever = KnowledgeRetriever(base_url="http://test")
+        retriever = KnowledgeRetriever(base_url="http://test", api_key="test-api-key")
         mock_response = mocker.Mock()
         mock_response.json.return_value = []
         mock_response.raise_for_status.return_value = None
@@ -82,11 +82,11 @@ class TestKnowledgeRetriever:
                 "query": "query",
                 "max_results": 10,
             },
-            headers={"user-id": "user-1"},
+            headers={"user-id": "user-1", "X-API-KEY": "test-api-key"},
         )
 
     def test_search_returns_empty_list_on_http_error(self, caplog, mocker):
-        retriever = KnowledgeRetriever(base_url="http://test")
+        retriever = KnowledgeRetriever(base_url="http://test", api_key="test-api-key")
 
         mock_response = mocker.Mock()
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
@@ -107,7 +107,7 @@ class TestKnowledgeRetriever:
         assert "RAG Lookup failed" in caplog.text
 
     def test_search_logs_json_body_on_http_error_when_available(self, caplog, mocker):
-        retriever = KnowledgeRetriever(base_url="http://test")
+        retriever = KnowledgeRetriever(base_url="http://test", api_key="test-api-key")
         mock_http_response = mocker.Mock()
         mock_http_response.status_code = 500
         mock_http_response.reason_phrase = "Internal Server Error"
@@ -135,7 +135,7 @@ class TestKnowledgeRetriever:
     def test_search_falls_back_to_text_on_http_error_when_json_unavailable(
         self, caplog, mocker
     ):
-        retriever = KnowledgeRetriever(base_url="http://test")
+        retriever = KnowledgeRetriever(base_url="http://test", api_key="test-api-key")
         mock_http_response = mocker.Mock()
         mock_http_response.status_code = 500
         mock_http_response.reason_phrase = "Internal Server Error"
@@ -161,7 +161,7 @@ class TestKnowledgeRetriever:
         assert "HTML error page" in caplog.text
 
     def test_search_returns_empty_list_on_connection_error(self, caplog, mocker):
-        retriever = KnowledgeRetriever(base_url="http://test")
+        retriever = KnowledgeRetriever(base_url="http://test", api_key="test-api-key")
 
         mock_client = mocker.patch("httpx.Client")
         mock_client_instance = mock_client.return_value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,7 @@ def set_test_env(monkeypatch, bedrock_generation_models):
     monkeypatch.setenv("AWS_BEDROCK_USE_CREDENTIALS", "False")
     monkeypatch.setenv("SQS_USE_CREDENTIALS", "false")
     monkeypatch.setenv("KNOWLEDGE_BASE_URL", "http://knowledge-base.com")
+    monkeypatch.setenv("AI_DEFRA_SEARCH_KNOWLEDGE_API_KEY", "test-knowledge-api-key")
     monkeypatch.setenv(
         "SQS_CHAT_QUEUE_URL",
         "http://sqs.eu-central-1.localstack:4566/000000000000/chat-job-queue",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -104,6 +104,8 @@ def test_bedrock_config_env_var_overrides(monkeypatch):
 
 def test_knowledge_config_loads_without_knowledge_group_id(monkeypatch):
     monkeypatch.setenv("KNOWLEDGE_BASE_URL", "http://knowledge-service:8087")
+    monkeypatch.setenv("AI_DEFRA_SEARCH_KNOWLEDGE_API_KEY", "test-api-key")
     knowledge_config = config.KnowledgeConfig()
     assert knowledge_config.base_url == "http://knowledge-service:8087"
+    assert knowledge_config.api_key.get_secret_value() == "test-api-key"
     assert not hasattr(knowledge_config, "knowledge_group_id")


### PR DESCRIPTION
AICE-469 - pass the X-API-KEY header when calling the knowledge service http endpoints