### PR TITLE
Disable automated GitHub Actions triggers

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -1,15 +1,20 @@
+# DISABLED (2026-04-17): Automated triggers removed as a security precaution
+# while repositories are being disabled. To re-enable, restore the original
+# 'on:' triggers from the commented block below.
 name: Check Pull Request
 
+# on:
+#   pull_request:
+#     branches:
+#       - main
+#     types:
+#       - opened
+#       - edited
+#       - reopened
+#       - synchronize
+#       - ready_for_review
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-      - ready_for_review
+  workflow_dispatch:
 
 jobs:
   security-scan:

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -1,3 +1,5 @@
+# DISABLED (2026-04-17): Workflow retained but should not be triggered while
+# repositories are being disabled as a security precaution.
 name: Publish Hot Fix
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,14 @@
+# DISABLED (2026-04-17): Automated triggers removed as a security precaution
+# while repositories are being disabled. To re-enable, restore the original
+# 'on:' triggers from the commented block below.
 name: Publish
 
+# on:
+#   push:
+#     branches:
+#       - main
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,8 +1,14 @@
+# DISABLED (2026-04-17): Automated triggers removed as a security precaution
+# while repositories are being disabled. To re-enable, restore the original
+# 'on:' triggers from the commented block below.
+
+# on:
+#   schedule:
+#     - cron: '0 1 * * *'
+#   workflow_dispatch:
+#   workflow_call:
 on:
-  schedule:
-    - cron: '0 1 * * *'
   workflow_dispatch:
-  workflow_call:
 
 jobs:
   sonarcloud: 


### PR DESCRIPTION
## Summary
- Commented out all automated triggers (push, pull_request, schedule, workflow_call) across all GitHub Actions workflows
- Replaced with `workflow_dispatch` (manual-only) as a security precaution while repositories are being disabled
- Original triggers preserved as comments for easy re-enablement

## Test plan
- [ ] Verify no workflows trigger on push to main
- [ ] Verify no workflows trigger on PR creation
- [ ] Verify workflows can still be manually dispatched if needed